### PR TITLE
feat: search and package info tools

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,15 +47,21 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     );
 
     let rate_limit = Duration::from_millis(args.rate_limit_ms);
-    let _state =
+    let state =
         Arc::new(AppState::new(rate_limit).map_err(|e| format!("Failed to create state: {e}"))?);
 
     let instructions = "MCP server for querying hex.pm - the Elixir/Erlang package registry.\n\n\
-         Tools will be added in subsequent releases.";
+         Available tools:\n\
+         - search_packages: Search for packages by name or keywords\n\
+         - get_package_info: Get detailed package information\n\
+         - get_package_versions: List all versions with retirement info";
 
     let router = McpRouter::new()
         .server_info("hexpm-mcp", env!("CARGO_PKG_VERSION"))
-        .instructions(instructions);
+        .instructions(instructions)
+        .tool(hexpm_mcp::tools::search::build(state.clone()))
+        .tool(hexpm_mcp::tools::info::build(state.clone()))
+        .tool(hexpm_mcp::tools::info::build_versions(state.clone()));
 
     match args.transport {
         Transport::Stdio => {

--- a/src/tools/info.rs
+++ b/src/tools/info.rs
@@ -1,0 +1,190 @@
+//! Get package info tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+use crate::tools::PackageInput;
+
+/// Build the `get_package_info` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_package_info")
+        .title("Get Package Info")
+        .description(
+            "Get detailed information about a hex.pm package including description, \
+             licenses, download stats, latest version, links, and docs URL.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PackageInput>| async move {
+                let pkg = state
+                    .client
+                    .get_package(&input.name)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                let mut output = format!("# {}\n\n", pkg.name);
+
+                if let Some(meta) = &pkg.meta
+                    && let Some(desc) = &meta.description
+                {
+                    output.push_str(&format!("{}\n\n", desc.trim()));
+                }
+
+                // Versions
+                output.push_str("## Versions\n\n");
+                if let Some(latest) = &pkg.latest_stable_version {
+                    output.push_str(&format!("- Latest Stable: **{}**\n", latest));
+                }
+                if let Some(latest) = &pkg.latest_version
+                    && pkg.latest_version != pkg.latest_stable_version
+                {
+                    output.push_str(&format!("- Latest: **{}**\n", latest));
+                }
+
+                // Downloads
+                if let Some(downloads) = &pkg.downloads {
+                    output.push_str("\n## Downloads\n\n");
+                    if let Some(all) = downloads.all {
+                        output.push_str(&format!("- All-time: {}\n", format_number(all)));
+                    }
+                    if let Some(recent) = downloads.recent {
+                        output
+                            .push_str(&format!("- Recent (90 days): {}\n", format_number(recent)));
+                    }
+                    if let Some(week) = downloads.week {
+                        output.push_str(&format!("- This week: {}\n", format_number(week)));
+                    }
+                    if let Some(day) = downloads.day {
+                        output.push_str(&format!("- Today: {}\n", format_number(day)));
+                    }
+                }
+
+                // Dates
+                if pkg.inserted_at.is_some() || pkg.updated_at.is_some() {
+                    output.push_str("\n## Dates\n\n");
+                    if let Some(created) = pkg.inserted_at {
+                        output.push_str(&format!("- Created: {}\n", created.date_naive()));
+                    }
+                    if let Some(updated) = pkg.updated_at {
+                        output.push_str(&format!("- Updated: {}\n", updated.date_naive()));
+                    }
+                }
+
+                // Links
+                if let Some(docs_url) = &pkg.docs_html_url {
+                    output.push_str(&format!("\n## Links\n\n- Documentation: {}\n", docs_url));
+                }
+                if let Some(html_url) = &pkg.html_url {
+                    output.push_str(&format!("- hex.pm: {}\n", html_url));
+                }
+                if let Some(meta) = &pkg.meta
+                    && let Some(links) = &meta.links
+                {
+                    for (label, url) in links {
+                        output.push_str(&format!("- {}: {}\n", label, url));
+                    }
+                }
+
+                // Licenses
+                if let Some(meta) = &pkg.meta {
+                    if let Some(licenses) = &meta.licenses
+                        && !licenses.is_empty()
+                    {
+                        output.push_str(&format!("\n## Licenses\n\n{}\n", licenses.join(", ")));
+                    }
+
+                    // Build tools
+                    if let Some(tools) = &meta.build_tools
+                        && !tools.is_empty()
+                    {
+                        output.push_str(&format!("\n## Build Tools\n\n{}\n", tools.join(", ")));
+                    }
+
+                    // Elixir version
+                    if let Some(elixir) = &meta.elixir {
+                        output.push_str(&format!("\n## Elixir\n\n{}\n", elixir));
+                    }
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+
+/// Build the `get_package_versions` tool.
+pub fn build_versions(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_package_versions")
+        .title("Get Package Versions")
+        .description(
+            "List all versions of a hex.pm package with docs status, \
+             publish date, and retirement information.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PackageInput>| async move {
+                let pkg = state
+                    .client
+                    .get_package(&input.name)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                let releases = pkg.releases.unwrap_or_default();
+                let retirements = pkg.retirements.unwrap_or_default();
+
+                if releases.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "No versions found for '{}'.",
+                        input.name
+                    )));
+                }
+
+                let mut output = format!("# {} - {} versions\n\n", input.name, releases.len());
+
+                for release in &releases {
+                    let docs_icon = if release.has_docs == Some(true) {
+                        "[docs]"
+                    } else {
+                        ""
+                    };
+
+                    let date = release
+                        .inserted_at
+                        .map(|d| d.date_naive().to_string())
+                        .unwrap_or_default();
+
+                    let retirement_info = retirements.get(&release.version);
+
+                    if let Some(retirement) = retirement_info {
+                        let reason = retirement.reason.as_deref().unwrap_or("unknown");
+                        let msg = retirement
+                            .message
+                            .as_deref()
+                            .map(|m| format!(" - {}", m))
+                            .unwrap_or_default();
+                        output.push_str(&format!(
+                            "- **{}** {} {} [RETIRED: {}{}]\n",
+                            release.version, date, docs_icon, reason, msg
+                        ));
+                    } else {
+                        output.push_str(&format!(
+                            "- **{}** {} {}\n",
+                            release.version, date, docs_icon
+                        ));
+                    }
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Each tool module exposes a `build(state: Arc<AppState>) -> Tool` function.
 
+pub mod info;
+pub mod search;
+
 use schemars::JsonSchema;
 use serde::Deserialize;
 

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -1,0 +1,73 @@
+//! Search packages tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+use crate::tools::SearchInput;
+
+/// Build the `search_packages` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("search_packages")
+        .title("Search Packages")
+        .description(
+            "Search for packages on hex.pm. Returns package names, descriptions, \
+             download counts, and latest versions.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SearchInput>| async move {
+                let packages = state
+                    .client
+                    .search_packages(&input.query, input.page, input.sort.as_deref())
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                if packages.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "No packages found matching '{}'.",
+                        input.query
+                    )));
+                }
+
+                let mut output = format!(
+                    "Found {} packages matching '{}':\n\n",
+                    packages.len(),
+                    input.query
+                );
+
+                for (i, pkg) in packages.iter().enumerate() {
+                    let version = pkg
+                        .latest_stable_version
+                        .as_deref()
+                        .or(pkg.latest_version.as_deref())
+                        .unwrap_or("?");
+
+                    output.push_str(&format!("{}. **{}** v{}\n", i + 1, pkg.name, version));
+
+                    if let Some(meta) = &pkg.meta
+                        && let Some(desc) = &meta.description
+                    {
+                        output.push_str(&format!("   {}\n", desc.trim()));
+                    }
+
+                    if let Some(downloads) = &pkg.downloads {
+                        let all = downloads.all.map(format_number).unwrap_or_default();
+                        let recent = downloads.recent.map(format_number).unwrap_or_default();
+                        output.push_str(&format!("   Downloads: {} | Recent: {}\n", all, recent));
+                    }
+
+                    output.push('\n');
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}


### PR DESCRIPTION
## Summary

Done. The commit adds three tools registered in the MCP router:

- **`search_packages`** (`src/tools/search.rs`) - searches hex.pm packages with optional sort/pagination, formats results with name, description, and download stats
- **`get_package_info`** (`src/tools/info.rs:build`) - returns full package detail: description, versions, downloads, dates, links, licenses, build tools, elixir version
- **`get_package_versions`** (`src/tools/info.rs:build_versions`) - lists all versions with docs sta

## Test results

All three checks pass:

- **`cargo fmt`** — no formatting issues
- **`cargo clippy`** — no warnings
- **`cargo test`** — 4 tests passed, 0 failures

No fixes needed. The implementation for #2 is clean.

---
Generated by arsenale | Cost: $0.84 | Closes #2