### PR TITLE
feat: release details, dependencies, and reverse dependencies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,14 +54,20 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          Available tools:\n\
          - search_packages: Search for packages by name or keywords\n\
          - get_package_info: Get detailed package information\n\
-         - get_package_versions: List all versions with retirement info";
+         - get_package_versions: List all versions with retirement info\n\
+         - get_release: Get detailed release information including deps and retirement\n\
+         - get_dependencies: Get dependencies for a package version\n\
+         - get_reverse_dependencies: Find packages that depend on a given package";
 
     let router = McpRouter::new()
         .server_info("hexpm-mcp", env!("CARGO_PKG_VERSION"))
         .instructions(instructions)
         .tool(hexpm_mcp::tools::search::build(state.clone()))
         .tool(hexpm_mcp::tools::info::build(state.clone()))
-        .tool(hexpm_mcp::tools::info::build_versions(state.clone()));
+        .tool(hexpm_mcp::tools::info::build_versions(state.clone()))
+        .tool(hexpm_mcp::tools::release::build(state.clone()))
+        .tool(hexpm_mcp::tools::dependencies::build(state.clone()))
+        .tool(hexpm_mcp::tools::reverse::build(state.clone()));
 
     match args.transport {
         Transport::Stdio => {

--- a/src/tools/dependencies.rs
+++ b/src/tools/dependencies.rs
@@ -1,0 +1,77 @@
+//! Get dependencies tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::AppState;
+use crate::tools::PackageVersionInput;
+
+/// Build the `get_dependencies` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_dependencies")
+        .title("Get Dependencies")
+        .description(
+            "Get the dependencies (requirements) of a hex.pm package. \
+             Optionally specify a version; defaults to the latest version.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<PackageVersionInput>| async move {
+                // Resolve version: use provided or fetch latest
+                let version = match input.version {
+                    Some(v) => v,
+                    None => {
+                        let pkg = state
+                            .client
+                            .get_package(&input.name)
+                            .await
+                            .tool_context("hex.pm API error")?;
+                        pkg.latest_stable_version
+                            .or(pkg.latest_version)
+                            .unwrap_or_else(|| "latest".to_string())
+                    }
+                };
+
+                let deps = state
+                    .client
+                    .get_dependencies(&input.name, &version)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                if deps.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "# {} v{}\n\nNo dependencies.",
+                        input.name, version
+                    )));
+                }
+
+                let mut output = format!(
+                    "# {} v{} - {} dependencies\n\n",
+                    input.name,
+                    version,
+                    deps.len()
+                );
+
+                let mut deps: Vec<_> = deps.iter().collect();
+                deps.sort_by_key(|(name, _)| *name);
+
+                for (name, req) in &deps {
+                    let optional = if req.optional { " (optional)" } else { "" };
+                    output.push_str(&format!(
+                        "- **{}** `{}`{}\n",
+                        name, req.requirement, optional
+                    ));
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,7 +2,10 @@
 //!
 //! Each tool module exposes a `build(state: Arc<AppState>) -> Tool` function.
 
+pub mod dependencies;
 pub mod info;
+pub mod release;
+pub mod reverse;
 pub mod search;
 
 use schemars::JsonSchema;

--- a/src/tools/release.rs
+++ b/src/tools/release.rs
@@ -1,0 +1,109 @@
+//! Get release details tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+use crate::tools::ReleaseInput;
+
+/// Build the `get_release` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_release")
+        .title("Get Release")
+        .description(
+            "Get detailed information about a specific hex.pm package release including \
+             version details, requirements (dependencies), publisher, retirement status, \
+             build tools, and elixir version requirement.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ReleaseInput>| async move {
+                let release = state
+                    .client
+                    .get_release(&input.name, &input.version)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                let mut output = format!("# {} v{}\n\n", input.name, release.version);
+
+                // Retirement (prominent)
+                if let Some(retirement) = &release.retirement {
+                    let reason = retirement.reason.as_deref().unwrap_or("unknown");
+                    output.push_str(&format!("## RETIRED: {}\n\n", reason));
+                    if let Some(msg) = &retirement.message {
+                        output.push_str(&format!("{}\n\n", msg));
+                    }
+                }
+
+                // Publisher
+                if let Some(publisher) = &release.publisher {
+                    output.push_str(&format!("Published by: **{}**\n", publisher.username));
+                }
+
+                // Dates
+                if let Some(date) = release.inserted_at {
+                    output.push_str(&format!("Published: {}\n", date.date_naive()));
+                }
+                if let Some(date) = release.updated_at {
+                    output.push_str(&format!("Updated: {}\n", date.date_naive()));
+                }
+
+                // Downloads
+                if let Some(downloads) = release.downloads {
+                    output.push_str(&format!("Downloads: {}\n", format_number(downloads)));
+                }
+
+                // Docs
+                if release.has_docs == Some(true) {
+                    output.push_str("Docs: available");
+                    if let Some(docs_url) = &release.docs_html_url {
+                        output.push_str(&format!(" ({})", docs_url));
+                    }
+                    output.push('\n');
+                }
+
+                // Build metadata
+                if let Some(meta) = &release.meta {
+                    if let Some(elixir) = &meta.elixir {
+                        output.push_str(&format!("\n## Elixir\n\n{}\n", elixir));
+                    }
+                    if let Some(tools) = &meta.build_tools
+                        && !tools.is_empty()
+                    {
+                        output.push_str(&format!("\n## Build Tools\n\n{}\n", tools.join(", ")));
+                    }
+                }
+
+                // Requirements (dependencies)
+                let requirements = release.requirements.unwrap_or_default();
+                if requirements.is_empty() {
+                    output.push_str("\n## Dependencies\n\nNone\n");
+                } else {
+                    output.push_str(&format!("\n## Dependencies ({})\n\n", requirements.len()));
+                    let mut deps: Vec<_> = requirements.iter().collect();
+                    deps.sort_by_key(|(name, _)| *name);
+                    for (name, req) in &deps {
+                        let optional = if req.optional { " (optional)" } else { "" };
+                        output.push_str(&format!(
+                            "- **{}** `{}`{}\n",
+                            name, req.requirement, optional
+                        ));
+                    }
+                }
+
+                // Links
+                if let Some(url) = &release.html_url {
+                    output.push_str(&format!("\n## Links\n\n- hex.pm: {}\n", url));
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/reverse.rs
+++ b/src/tools/reverse.rs
@@ -1,0 +1,77 @@
+//! Get reverse dependencies tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+use crate::tools::PackageInput;
+
+/// Build the `get_reverse_dependencies` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_reverse_dependencies")
+        .title("Get Reverse Dependencies")
+        .description(
+            "Find packages that depend on a given hex.pm package, \
+             with download counts.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PackageInput>| async move {
+                let page = state
+                    .client
+                    .get_reverse_dependencies(&input.name, None)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                let packages = page.packages.unwrap_or_default();
+
+                if packages.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "No packages depend on '{}'.",
+                        input.name
+                    )));
+                }
+
+                let mut output = format!(
+                    "# Packages that depend on {} ({} found)\n\n",
+                    input.name,
+                    packages.len()
+                );
+
+                for pkg in &packages {
+                    let downloads = pkg
+                        .downloads
+                        .as_ref()
+                        .and_then(|d| d.all)
+                        .map(|n| format!(" ({}  downloads)", format_number(n)))
+                        .unwrap_or_default();
+
+                    let desc = pkg
+                        .meta
+                        .as_ref()
+                        .and_then(|m| m.description.as_deref())
+                        .unwrap_or("");
+
+                    if desc.is_empty() {
+                        output.push_str(&format!("- **{}**{}\n", pkg.name, downloads));
+                    } else {
+                        output.push_str(&format!(
+                            "- **{}**{} - {}\n",
+                            pkg.name,
+                            downloads,
+                            desc.lines().next().unwrap_or("")
+                        ));
+                    }
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}


### PR DESCRIPTION
## Summary

Done. Three new tools implemented:

- **`get_release`** (`src/tools/release.rs`) - Full release details including retirement status (displayed prominently), publisher, build tools, elixir version, and dependencies
- **`get_dependencies`** (`src/tools/dependencies.rs`) - Extracts requirements for a version (defaults to latest if no version specified)
- **`get_reverse_dependencies`** (`src/tools/reverse.rs`) - Finds packages that depend on a given package using the hex.pm reverse dependencies endp

## Test results

All three checks pass:

- **`cargo fmt`** - no formatting issues
- **`cargo clippy`** - no warnings
- **`cargo test`** - 4 tests passed, 0 failures

No fixes needed. The implementation for issue #3 is clean.

---
Generated by arsenale | Cost: $0.68 | Closes #3