### PR TITLE
feat: download stats, owners, and comparison tools

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_package_versions: List all versions with retirement info\n\
          - get_release: Get detailed release information including deps and retirement\n\
          - get_dependencies: Get dependencies for a package version\n\
-         - get_reverse_dependencies: Find packages that depend on a given package";
+         - get_reverse_dependencies: Find packages that depend on a given package\n\
+         - get_downloads: Get download statistics for a package\n\
+         - get_owners: Get package owners/maintainers\n\
+         - compare_packages: Compare 2-4 packages side by side";
 
     let router = McpRouter::new()
         .server_info("hexpm-mcp", env!("CARGO_PKG_VERSION"))
@@ -67,7 +70,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .tool(hexpm_mcp::tools::info::build_versions(state.clone()))
         .tool(hexpm_mcp::tools::release::build(state.clone()))
         .tool(hexpm_mcp::tools::dependencies::build(state.clone()))
-        .tool(hexpm_mcp::tools::reverse::build(state.clone()));
+        .tool(hexpm_mcp::tools::reverse::build(state.clone()))
+        .tool(hexpm_mcp::tools::downloads::build(state.clone()))
+        .tool(hexpm_mcp::tools::owners::build(state.clone()))
+        .tool(hexpm_mcp::tools::compare::build(state.clone()));
 
     match args.transport {
         Transport::Stdio => {

--- a/src/tools/compare.rs
+++ b/src/tools/compare.rs
@@ -1,0 +1,204 @@
+//! Compare packages tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+
+/// Input for the compare_packages tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CompareInput {
+    /// Comma-separated list of package names to compare (2-4 packages).
+    packages: String,
+}
+
+/// Build the `compare_packages` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("compare_packages")
+        .title("Compare Packages")
+        .description(
+            "Compare 2-4 hex.pm packages side by side. Provide a comma-separated \
+             list of package names. Compares downloads, latest version, last updated, \
+             license, number of dependencies, and retirement status.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<CompareInput>| async move {
+                let names: Vec<&str> = input
+                    .packages
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+
+                if names.len() < 2 {
+                    return Ok(CallToolResult::text(
+                        "Please provide at least 2 package names to compare (comma-separated).",
+                    ));
+                }
+                if names.len() > 4 {
+                    return Ok(CallToolResult::text(
+                        "Please provide at most 4 package names to compare.",
+                    ));
+                }
+
+                // Fetch all packages
+                let mut packages = Vec::new();
+                for name in &names {
+                    match state.client.get_package(name).await {
+                        Ok(pkg) => packages.push(Ok(pkg)),
+                        Err(e) => packages.push(Err(format!("{e}"))),
+                    }
+                }
+
+                // Build table header
+                let mut header = "| Metric |".to_string();
+                let mut separator = "|--------|".to_string();
+                for name in &names {
+                    header.push_str(&format!(" {} |", name));
+                    separator.push_str("--------|");
+                }
+
+                let mut output = format!("# Package Comparison\n\n{}\n{}\n", header, separator);
+
+                // Downloads (all-time)
+                let mut row = "| Downloads (all-time) |".to_string();
+                for result in &packages {
+                    match result {
+                        Ok(pkg) => {
+                            let val = pkg
+                                .downloads
+                                .as_ref()
+                                .and_then(|d| d.all)
+                                .map(format_number)
+                                .unwrap_or_else(|| "N/A".to_string());
+                            row.push_str(&format!(" {} |", val));
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                // Downloads (recent)
+                let mut row = "| Downloads (90 days) |".to_string();
+                for result in &packages {
+                    match result {
+                        Ok(pkg) => {
+                            let val = pkg
+                                .downloads
+                                .as_ref()
+                                .and_then(|d| d.recent)
+                                .map(format_number)
+                                .unwrap_or_else(|| "N/A".to_string());
+                            row.push_str(&format!(" {} |", val));
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                // Latest version
+                let mut row = "| Latest version |".to_string();
+                for result in &packages {
+                    match result {
+                        Ok(pkg) => {
+                            let val = pkg
+                                .latest_stable_version
+                                .as_deref()
+                                .or(pkg.latest_version.as_deref())
+                                .unwrap_or("N/A");
+                            row.push_str(&format!(" {} |", val));
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                // Last updated
+                let mut row = "| Last updated |".to_string();
+                for result in &packages {
+                    match result {
+                        Ok(pkg) => {
+                            let val = pkg
+                                .updated_at
+                                .map(|d| d.date_naive().to_string())
+                                .unwrap_or_else(|| "N/A".to_string());
+                            row.push_str(&format!(" {} |", val));
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                // License
+                let mut row = "| License |".to_string();
+                for result in &packages {
+                    match result {
+                        Ok(pkg) => {
+                            let val = pkg
+                                .meta
+                                .as_ref()
+                                .and_then(|m| m.licenses.as_ref())
+                                .map(|l| l.join(", "))
+                                .unwrap_or_else(|| "N/A".to_string());
+                            row.push_str(&format!(" {} |", val));
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                // Number of deps (from latest release)
+                let mut row = "| Dependencies |".to_string();
+                for (i, result) in packages.iter().enumerate() {
+                    match result {
+                        Ok(pkg) => {
+                            let version = pkg
+                                .latest_stable_version
+                                .as_deref()
+                                .or(pkg.latest_version.as_deref());
+                            if let Some(ver) = version {
+                                match state.client.get_release(names[i], ver).await {
+                                    Ok(release) => {
+                                        let count =
+                                            release.requirements.as_ref().map_or(0, |r| r.len());
+                                        row.push_str(&format!(" {} |", count));
+                                    }
+                                    Err(_) => row.push_str(" N/A |"),
+                                }
+                            } else {
+                                row.push_str(" N/A |");
+                            }
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                // Retirement status
+                let mut row = "| Retired |".to_string();
+                for result in &packages {
+                    match result {
+                        Ok(pkg) => {
+                            let retired = pkg.retirements.as_ref().is_some_and(|r| !r.is_empty());
+                            let val = if retired { "Yes (some versions)" } else { "No" };
+                            row.push_str(&format!(" {} |", val));
+                        }
+                        Err(e) => row.push_str(&format!(" error: {} |", e)),
+                    }
+                }
+                output.push_str(&format!("{}\n", row));
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/downloads.rs
+++ b/src/tools/downloads.rs
@@ -1,0 +1,56 @@
+//! Get download stats tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+use crate::tools::PackageInput;
+
+/// Build the `get_downloads` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_downloads")
+        .title("Get Downloads")
+        .description(
+            "Get download statistics for a hex.pm package including \
+             all-time, recent (90 days), weekly, and daily counts.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PackageInput>| async move {
+                let pkg = state
+                    .client
+                    .get_package(&input.name)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                let mut output = format!("# {} - Download Stats\n\n", pkg.name);
+
+                if let Some(downloads) = &pkg.downloads {
+                    if let Some(all) = downloads.all {
+                        output.push_str(&format!("- All-time: {}\n", format_number(all)));
+                    }
+                    if let Some(recent) = downloads.recent {
+                        output
+                            .push_str(&format!("- Recent (90 days): {}\n", format_number(recent)));
+                    }
+                    if let Some(week) = downloads.week {
+                        output.push_str(&format!("- This week: {}\n", format_number(week)));
+                    }
+                    if let Some(day) = downloads.day {
+                        output.push_str(&format!("- Today: {}\n", format_number(day)));
+                    }
+                } else {
+                    output.push_str("No download statistics available.\n");
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,8 +2,11 @@
 //!
 //! Each tool module exposes a `build(state: Arc<AppState>) -> Tool` function.
 
+pub mod compare;
 pub mod dependencies;
+pub mod downloads;
 pub mod info;
+pub mod owners;
 pub mod release;
 pub mod reverse;
 pub mod search;

--- a/src/tools/owners.rs
+++ b/src/tools/owners.rs
@@ -1,0 +1,58 @@
+//! Get package owners tool
+
+use std::sync::Arc;
+
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::AppState;
+use crate::tools::PackageInput;
+
+/// Build the `get_owners` tool.
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_owners")
+        .title("Get Owners")
+        .description(
+            "Get the list of owners/maintainers for a hex.pm package \
+             with their usernames and email addresses.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PackageInput>| async move {
+                let owners = state
+                    .client
+                    .get_owners(&input.name)
+                    .await
+                    .tool_context("hex.pm API error")?;
+
+                if owners.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "No owners found for '{}'.",
+                        input.name
+                    )));
+                }
+
+                let mut output = format!(
+                    "# {} - {} owner{}\n\n",
+                    input.name,
+                    owners.len(),
+                    if owners.len() == 1 { "" } else { "s" }
+                );
+
+                for owner in &owners {
+                    output.push_str(&format!("- **{}**", owner.username));
+                    if let Some(email) = &owner.email {
+                        output.push_str(&format!(" ({})", email));
+                    }
+                    output.push('\n');
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}


### PR DESCRIPTION
## Summary

Done. Three new tools added:

- **`get_downloads`** (`src/tools/downloads.rs`) - Fetches package download stats (all-time, 90-day, weekly, daily) via `GET /api/packages/{name}`
- **`get_owners`** (`src/tools/owners.rs`) - Lists maintainers with usernames and emails via `GET /api/packages/{name}/owners`
- **`compare_packages`** (`src/tools/compare.rs`) - Side-by-side comparison of 2-4 packages (downloads, version, updated date, license, deps count, retirement status)

All validation passes: fmt, 

## Test results

All three checks pass:

- **`cargo fmt --all -- --check`** — no formatting issues
- **`cargo clippy --all-targets --all-features -- -D warnings`** — no warnings
- **`cargo test --all-features`** — 4 tests passed, 0 failures

No fixes needed. The implementation for issue #4 is clean.

---
Generated by arsenale | Cost: $0.71 | Closes #4