### PR TITLE
ci: release-plz setup for automated releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

Done. Added `.github/workflows/release-plz.yml` based on the cratesio-mcp pattern, targeting the `master` branch. It will:

- Trigger on pushes to `master`
- Use `release-plz/action@v0.5` for changelog generation and automated crates.io publishing
- Require `COMMITTER_TOKEN` and `CARGO_REGISTRY_TOKEN` secrets to be configured in the repo settings

## Test results

All three checks pass:

- **`cargo fmt`** - no formatting issues
- **`cargo clippy`** - no warnings
- **`cargo test`** - 9/9 tests passed (4 unit + 5 integration)

No fixes needed.

---
Generated by arsenale | Cost: $0.26 | Closes #16