### PR TITLE
fix: derive server version from mix and de-flake health test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ hexpm_mcp-*.tar
 .elixir_ls/
 CLAUDE.md
 books.json
+
+# macOS
+.DS_Store
+
+# Node (not used by this project; ignore accidental drops from tooling)
+/node_modules/
+/package.json
+/package-lock.json

--- a/lib/hexpm_mcp/mcp/server.ex
+++ b/lib/hexpm_mcp/mcp/server.ex
@@ -3,9 +3,13 @@ defmodule HexpmMcp.MCP.Server do
   Anubis MCP server definition for hexpm-mcp.
   """
 
+  # Keep the advertised server version in lockstep with mix.exs. Resolved at
+  # compile time and baked in as a literal, so there is no runtime Mix dependency.
+  @version Mix.Project.config()[:version]
+
   use Anubis.Server,
     name: "hexpm-mcp",
-    version: "0.1.0",
+    version: @version,
     capabilities: [
       :tools,
       :resources,

--- a/test/hexpm_mcp_test.exs
+++ b/test/hexpm_mcp_test.exs
@@ -305,6 +305,10 @@ defmodule HexpmMcpTest do
 
   describe "health_check/1" do
     test "returns structured health report", %{bypass: bypass} do
+      # Keep updated_at < 90 days old so maintenance status is "Active". Computed
+      # relative to now so the assertion doesn't rot as wall-clock time passes.
+      recent = DateTime.utc_now() |> DateTime.add(-30, :day) |> DateTime.to_iso8601()
+
       Bypass.stub(bypass, "GET", "/packages/req", fn conn ->
         respond_json(
           conn,
@@ -313,7 +317,7 @@ defmodule HexpmMcpTest do
             downloads_all: 11_000_000,
             downloads_recent: 1_600_000,
             inserted_at: "2022-01-01T00:00:00Z",
-            updated_at: "2026-02-01T00:00:00Z"
+            updated_at: recent
           )
         )
       end)


### PR DESCRIPTION
Repo housekeeping after picking the project back up. Three fixes:

## 1. Server reports the wrong version (user-facing)
The MCP handshake hardcoded `serverInfo.version` as `"0.1.0"` in `server.ex` while the project is at `0.3.0`. Every connecting client saw `0.1.0`. Now resolved from the mix project version at compile time (`@version Mix.Project.config()[:version]`) and baked in as a literal -- no runtime Mix dependency. Verified: `server_info/0` now returns `%{"name" => "hexpm-mcp", "version" => "0.3.0"}`.

## 2. CI is silently red (time-bomb test)
`test/hexpm_mcp_test.exs` pinned a fixture `updated_at` of `2026-02-01` and asserted maintenance status `"Active"`, which requires `< 90` days. `maintenance_status/1` uses real `DateTime.utc_now()`, so once that date aged past 90 days the test started failing. The last green CI run was 2026-04-06 (still inside the window); the suite fails today. Fixed by computing the fixture date relative to now so it can't rot.

## 3. Stray files
Ignore `.DS_Store` and the accidental Node droppings (`package.json` = `{}`, tiny `package-lock.json`) that tooling left in the repo root; removed the existing ones.

## Verification
- `mix format --check-formatted` clean
- `mix test` -> 62 passed (was 61/62 with the time-bomb failing)
- `mix compile --warnings-as-errors` clean

Note: `mix credo --strict` crashes locally on Elixir 1.20.1 (credo 1.7.17 can't parse the new sigil token format); CI runs on Elixir 1.19 where it's fine -- unrelated to this change.