### PR TITLE
feat: expose the three hexdocs browsing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A public instance is running at `https://hexpm-mcp.fly.dev/mcp`. Add it to your 
 
 ## Features
 
-- 16 tools for searching, inspecting, comparing, and auditing hex.pm packages
+- 19 tools for searching, inspecting, comparing, and auditing hex.pm packages
 - 3 URI-template resources for structured package data access
 - 5 guided analysis prompts
 - HexDocs browsing (module listing, doc search, full module docs)

--- a/lib/hexpm_mcp/mcp/server.ex
+++ b/lib/hexpm_mcp/mcp/server.ex
@@ -34,6 +34,11 @@ defmodule HexpmMcp.MCP.Server do
   component(HexpmMcp.MCP.Tools.AuditMixDeps)
   component(HexpmMcp.MCP.Tools.UpgradeCheck)
 
+  # HexDocs browsing tools
+  component(HexpmMcp.MCP.Tools.Docs)
+  component(HexpmMcp.MCP.Tools.SearchDocs)
+  component(HexpmMcp.MCP.Tools.DocItem)
+
   # Resources
   component(HexpmMcp.MCP.Resources.PackageInfo)
   component(HexpmMcp.MCP.Resources.PackageReadme)


### PR DESCRIPTION
The `docs`, `search_docs`, and `doc_item` tools were written in the original Elixir rewrite (commit 53fc1f3) but their `component(...)` registrations were never added to `server.ex`. As a result the live server advertised **16 tools** while the README's tool tables, the CLAUDE.md design notes, and the Features list all described **19** -- HexDocs browsing was documented but not actually callable.

This wires them in. Their backing API (`HexpmMcp.get_docs/2`, `search_docs/3`, `get_doc_item/3`) and formatters (`format_docs/3`, `format_search_docs/3`) already exist and are exercised at the API layer; only the registration was missing.

## Changes
- Register `Tools.Docs`, `Tools.SearchDocs`, `Tools.DocItem` in `lib/hexpm_mcp/mcp/server.ex`
- Update the stale "16 tools" count in the README to 19 (the tool tables already listed all 19)

## Verification
- `mix compile --warnings-as-errors` clean
- `HexpmMcp.MCP.Server.__components__(:tool)` now returns 19 tools, including `docs`, `doc_item`, `search_docs`
- `mix format --check-formatted` clean
- `mix test` -> 61/62 (the one failure is the pre-existing time-bomb health test, **not** related to this change)

## Merge order
This branch is cut from `main`, so its CI will show the same pre-existing health-test failure that #45 fixes. Merge #45 first, then update this branch (it touches different lines, so it'll go green with no conflict).