### PR TITLE
docs: add MCP registry manifest and drop broken hex badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # hexpm-mcp
 
 [![CI](https://github.com/joshrotenberg/hexpm-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/hexpm-mcp/actions/workflows/ci.yml)
-[![Hex.pm](https://img.shields.io/hexpm/v/hexpm_mcp.svg)](https://hex.pm/packages/hexpm_mcp)
 ![Elixir](https://img.shields.io/badge/Elixir-1.17%2B-blueviolet)
 ![OTP](https://img.shields.io/badge/OTP-28-blue)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.joshrotenberg/hexpm-mcp",
+  "title": "Hex.pm MCP",
+  "description": "MCP server for hex.pm and hexdocs.pm: search, inspect, compare, and audit Elixir/Erlang packages, browse docs, and check dependencies for vulnerabilities.",
+  "version": "0.3.0",
+  "websiteUrl": "https://github.com/joshrotenberg/hexpm-mcp",
+  "repository": {
+    "url": "https://github.com/joshrotenberg/hexpm-mcp",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://hexpm-mcp.fly.dev/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adoption groundwork. The README is already solid (remote quick-start + local stdio section + full tool tables), so the gap is **discoverability**, not docs -- the project isn't in any MCP registry or directory, which is what drives the comparable `9elements/hex-mcp` server's visibility.

## Changes
- **`server.json`** -- registry manifest for the hosted server, validated against the `2025-12-11` MCP server schema. Declares the streamable-HTTP remote at `https://hexpm-mcp.fly.dev/mcp` under the reverse-DNS name `io.github.joshrotenberg/hexpm-mcp`. This is the artifact the official registry consumes and that community directories crawl.
- **Drop the broken `Hex.pm` badge** -- `hexpm-mcp` is a hosted server, not a published hex package (`mix.exs` has no `package` config), so the badge 404s.

## What this PR deliberately does NOT do (your call -- outward-facing)
These are the actual adoption actions; they publish to external services and need your go-ahead:

1. **Publish `server.json` to the official registry** -- needs the `mcp-publisher` CLI + GitHub OIDC auth for the `io.github.joshrotenberg/*` namespace.
2. **Submit to community directories** -- mcp.so, Glama, Smithery, PulseMCP, and the `punkpeye/awesome-mcp-servers` list (a PR).
3. **Optionally publish to hex.pm** as a runnable package, if you want a `mix`-installable local-stdio path (would require adding `package` config to `mix.exs` and would restore a working version badge).

## Merge order
Cut from `main`, so CI shows the same pre-existing health-test failure that #45 fixes. Merge #45 first.