### PR TITLE
fix: avoid atom exhaustion in mix deps parsing

### DIFF
--- a/lib/hexpm_mcp.ex
+++ b/lib/hexpm_mcp.ex
@@ -795,7 +795,7 @@ defmodule HexpmMcp do
       results =
         deps
         |> Task.async_stream(
-          fn {name, pinned} -> {name, pinned, audit_dep(Atom.to_string(name))} end,
+          fn {name, pinned} -> {name, pinned, audit_dep(name)} end,
           timeout: 30_000
         )
         |> Enum.map(fn {:ok, result} -> result end)
@@ -809,7 +809,7 @@ defmodule HexpmMcp do
         deps_with_warnings: Enum.count(results, fn {_, _, issues} -> issues != [] end),
         results:
           Enum.map(results, fn {name, pinned, issues} ->
-            %{name: Atom.to_string(name), pinned_version: pinned, issues: issues}
+            %{name: name, pinned_version: pinned, issues: issues}
           end)
       }
 
@@ -862,16 +862,14 @@ defmodule HexpmMcp do
   end
 
   defp check_upgrade({name, pinned}) do
-    name_str = Atom.to_string(name)
-
-    case Client.get_package(name_str) do
+    case Client.get_package(name) do
       {:ok, pkg} ->
         latest = pkg.latest_stable_version || pkg.latest_version
         retired = Map.has_key?(pkg.retirements || %{}, latest)
         status = classify_upgrade(pinned, latest)
 
         %{
-          name: name_str,
+          name: name,
           pinned_version: pinned,
           latest_version: latest,
           status: status,
@@ -880,7 +878,7 @@ defmodule HexpmMcp do
 
       {:error, _} ->
         %{
-          name: name_str,
+          name: name,
           pinned_version: pinned,
           latest_version: nil,
           status: :error,
@@ -930,9 +928,11 @@ defmodule HexpmMcp do
 
   @doc false
   def parse_deps_string(deps_string) do
+    # Keep names as strings: they are only used as package names for lookups,
+    # and String.to_atom on unbounded user input would exhaust the atom table.
     ~r/\{:(\w+),\s*"([^"]+)"/
     |> Regex.scan(deps_string)
-    |> Enum.map(fn [_, name, version] -> {String.to_atom(name), version} end)
+    |> Enum.map(fn [_, name, version] -> {name, version} end)
     |> Enum.uniq_by(fn {name, _} -> name end)
   end
 

--- a/test/hexpm_mcp_test.exs
+++ b/test/hexpm_mcp_test.exs
@@ -418,15 +418,20 @@ defmodule HexpmMcpTest do
 
       result = HexpmMcp.parse_deps_string(deps)
       assert length(result) == 3
-      assert {:phoenix, "~> 1.7"} in result
-      assert {:ecto, "~> 3.10"} in result
-      assert {:jason, "~> 1.0"} in result
+      assert {"phoenix", "~> 1.7"} in result
+      assert {"ecto", "~> 3.10"} in result
+      assert {"jason", "~> 1.0"} in result
     end
 
     test "handles exact versions" do
       deps = ~s({:plug, "1.15.0"})
       result = HexpmMcp.parse_deps_string(deps)
-      assert [{:plug, "1.15.0"}] = result
+      assert [{"plug", "1.15.0"}] = result
+    end
+
+    test "returns string names, not atoms (avoids atom-table exhaustion)" do
+      assert [{name, "1.0.0"}] = HexpmMcp.parse_deps_string(~s({:some_pkg, "1.0.0"}))
+      assert is_binary(name)
     end
 
     test "deduplicates" do


### PR DESCRIPTION
Security finding from a review pass over the input-handling surface.

## The issue (moderate -- DoS)
`parse_deps_string/1` ran `String.to_atom/1` on every package name extracted from the user-supplied deps string fed to `audit_mix_deps` / `upgrade_check`. Atoms are **never garbage collected**, so a client could send a deps string with many unique names (`{:a1, "1"}, {:a2, "1"}, ...`) and exhaust the BEAM atom table (~1M default), crashing the node. The server is public and unauthenticated, so this is reachable.

## The fix
Every consumer (`audit_mix_deps`, `upgrade_check`) immediately did `Atom.to_string(name)` to use it as a package-name string for lookups -- so the atom served no purpose beyond being a liability. Keep names as strings end-to-end:
- `parse_deps_string/1` returns `{string, version}` tuples
- `audit_mix_deps` / `check_upgrade` use the string directly (dropped the `Atom.to_string` round-trips)
- updated the `parse_deps_string` tests to the string contract + added a regression test asserting parsed names are binaries

## Verification
- `mix test` -> 63 passed (incl. new regression test)
- `mix compile --warnings-as-errors` clean; `mix format --check-formatted` clean

## Scope notes
- **No RCE path:** the deps string is parsed with a regex, never `Code.eval`/`Code.string_to_quoted`. A full grep for `Code.eval|System.cmd|binary_to_term|Port.open` across `lib/` is empty.
- **Low-priority follow-up (not in this PR):** package names flow into the API path (`/packages/#{name}`) without validation/encoding ([client.ex](lib/hexpm_mcp/client.ex)). It's benign for a read-only proxy to a fixed host (can't SSRF off hex.pm; worst case a 404), but validating against hex's `[a-z0-9_]` naming or URI-encoding would be reasonable defense-in-depth. Happy to do it if you want.

Based on current `main` (#45), so CI should be green directly.