### PR TITLE
ci: publish to Hex.pm on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,29 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  publish-hex:
+    name: Publish to Hex.pm
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28"
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Publish package and docs to Hex.pm
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+
   deploy:
     name: Deploy to Fly.io
     needs: release-please


### PR DESCRIPTION
Mirrors the existing Fly auto-deploy: when release-please cuts a release, publish the package + HexDocs to hex.pm automatically.

## What
Adds a `publish-hex` job to `release-please.yml`, gated on `release_created == 'true'` (runs in parallel with the Fly `deploy` job). It sets up Elixir, fetches deps, and runs `mix hex.publish --yes`, which publishes both the package and the docs to hexdocs.pm. The version comes from `mix.exs` (which release-please bumps), so each release ships its own version.

## ⚠️ Action required before the next release
1. **Add a `HEX_API_KEY` repo secret** (Settings → Secrets and variables → Actions). Generate one with `mix hex.user key generate --key-name hexpm-mcp-ci` (or from your hex.pm dashboard). Without it, the job fails.
2. The **first release** after this merges will **reserve the `hexpm_mcp` name** on hex.pm (semi-permanent) and publish v0.x.

## Notes
- Package metadata, LICENSE, and ex_doc config already landed in #49, so the package is publish-ready (`mix hex.build` and `mix docs` both verified clean).
- This only touches the workflow; no app code changes. CI should be green directly (based on current `main`).
- The deploy + this hex job are now both duplicated/parallel in `release-please.yml` — the reusable-workflow refactor I mentioned would DRY the deploy half, but hex publish is cleanly separate either way.