### PR TITLE
chore: sync server.json with published registry entry (0.3.1)

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.joshrotenberg/hexpm-mcp",
   "title": "Hex.pm MCP",
-  "description": "MCP server for hex.pm and hexdocs.pm: search, inspect, compare, and audit Elixir/Erlang packages, browse docs, and check dependencies for vulnerabilities.",
-  "version": "0.3.0",
+  "description": "MCP server for hex.pm and hexdocs.pm: search, inspect, compare, and audit Elixir packages",
+  "version": "0.3.1",
   "websiteUrl": "https://github.com/joshrotenberg/hexpm-mcp",
   "repository": {
     "url": "https://github.com/joshrotenberg/hexpm-mcp",


### PR DESCRIPTION
Syncs `main`'s `server.json` with what's now published to the MCP registry.

`io.github.joshrotenberg/hexpm-mcp` v0.3.1 is live and **active** in the registry (https://registry.modelcontextprotocol.io). This brings `main` in line:
- `version` 0.3.0 -> **0.3.1** (matches the release)
- `description` trimmed to <= 100 chars (the registry's hard limit -- the old one was 155 and would fail `mcp-publisher validate`/`publish`)

Verified with `mcp-publisher validate` (✅) and confirmed listed via the registry API.

Keeping `main` valid matters for any future re-publish (manual or automated). Happy to follow up with a `github-oidc` workflow that re-publishes to the registry on each release (parallel to the Fly deploy and the hex publish in #53).