### PR TITLE
ci: publish to hex on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,29 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  publish-hex:
+    name: Publish to Hex
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28"
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Publish to Hex
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+
   deploy:
     name: Deploy to Fly.io
     needs: release-please


### PR DESCRIPTION
## What

Adds a `publish-hex` job to the Release Please workflow that runs `mix hex.publish --yes` when release-please cuts a release, parallel to the existing Fly.io deploy.

The package metadata (#49) was already complete and `mix hex.build` succeeds, but the package was never published to hex.pm and there was no automated publish step. This wires it in.

## Details

- Gated on `release-please.outputs.release_created == 'true'`, same condition as the Fly deploy job.
- Uses `HEX_API_KEY` repo secret (now in place).
- Elixir 1.19 / OTP 28, matching CI.
- `mix hex.publish` publishes both the package and the docs.

## Follow-ups (not in this PR)

- **Version/tag drift:** `mix.exs` and `.release-please-manifest.json` say `0.3.0`, but a `v0.3.1` git tag exists (from release-please PR #47) that is not an ancestor of `main`. Release-please's next run may try to cut `0.3.1` again. Worth reconciling before the first automated publish so the hex version and git tag agree.
- **First publish is manual or via next release.** This job only fires when release-please creates a release. The current `main` (0.3.0) has no corresponding hex release; either publish 0.3.0 manually once, or let the next release-please PR carry the first automated publish.