### PR TITLE
docs: add hex badges and library install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # hexpm-mcp
 
 [![CI](https://github.com/joshrotenberg/hexpm-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/hexpm-mcp/actions/workflows/ci.yml)
+[![Hex.pm](https://img.shields.io/hexpm/v/hexpm_mcp.svg)](https://hex.pm/packages/hexpm_mcp)
+[![Docs](https://img.shields.io/badge/hexdocs-docs-purple.svg)](https://hexdocs.pm/hexpm_mcp)
 ![Elixir](https://img.shields.io/badge/Elixir-1.17%2B-blueviolet)
 ![OTP](https://img.shields.io/badge/OTP-28-blue)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
@@ -150,7 +152,16 @@ To run from source with stdio transport (e.g. for development):
 
 ### iex
 
-The public API is available directly from iex without the MCP server:
+The public API is available directly from iex without the MCP server. Add the
+package to your `mix.exs`:
+
+```elixir
+def deps do
+  [{:hexpm_mcp, "~> 0.3"}]
+end
+```
+
+Or run it straight from a checkout:
 
 ```elixir
 $ MIX_ENV=test iex -S mix


### PR DESCRIPTION
## What

Adds hex.pm and hexdocs badges to the README and documents installing `hexpm_mcp` as a dependency, now that the package publishes to hex.pm on release.

The hex badge was dropped in #48 while the package was unpublished (it 404'd). The public API exposes 20 functions usable from iex, so a standard `{:hexpm_mcp, "~> 0.3"}` install snippet belongs in the README.

## Why this PR exists

Beyond the docs, this commit carries a `Release-As: 0.3.2` footer. The only commits since the `v0.3.1` release are `ci:` and `test:` types, which release-please does not bump on, so no release PR was being opened. This forces release-please to cut **0.3.2**, whose merge will trigger the `publish-hex` job (added in #53) and produce the **first hex.pm release** of the package.

## Sequence once merged

1. Merge this PR to `main`.
2. release-please opens a `release 0.3.2` PR.
3. Merge that PR -> tag `v0.3.2` -> `publish-hex` runs `mix hex.publish` -> package + docs live on hex.pm.
4. The badges in this README resolve once that publish completes.