### PR TITLE
feat: add Elixir Toolbox discovery tools

### DIFF
--- a/lib/hexpm_mcp.ex
+++ b/lib/hexpm_mcp.ex
@@ -63,6 +63,29 @@ defmodule HexpmMcp do
   @type error ::
           :not_found | :rate_limited | {:api_error, integer(), any()} | {:request_failed, any()}
 
+  # ---------------------------------------------------------------------------
+  # Elixir Toolbox (curated discovery)
+  #
+  # Thin delegates to `HexpmMcp.Toolbox`, which already returns parsed maps.
+  # ---------------------------------------------------------------------------
+
+  @doc "List all Elixir Toolbox groups with their categories."
+  defdelegate toolbox_groups(), to: HexpmMcp.Toolbox, as: :groups
+
+  @doc "Get a single Elixir Toolbox group by slug."
+  defdelegate toolbox_group(slug), to: HexpmMcp.Toolbox, as: :group
+
+  @doc "List curated projects in an Elixir Toolbox category."
+  defdelegate toolbox_category(group, category, opts \\ []),
+    to: HexpmMcp.Toolbox,
+    as: :category_projects
+
+  @doc "List trending Elixir Toolbox projects."
+  defdelegate toolbox_trending(opts \\ []), to: HexpmMcp.Toolbox, as: :trending
+
+  @doc "Search packages via Elixir Toolbox."
+  defdelegate toolbox_search(query), to: HexpmMcp.Toolbox, as: :search
+
   @doc """
   Search for packages on hex.pm by name/keywords.
 

--- a/lib/hexpm_mcp/formatter.ex
+++ b/lib/hexpm_mcp/formatter.ex
@@ -642,4 +642,111 @@ defmodule HexpmMcp.Formatter do
   defp status_to_label(:patch_upgrade), do: "patch upgrade available"
   defp status_to_label(:unknown), do: "upgrade status unknown"
   defp status_to_label(_), do: "unknown"
+
+  # ---------------------------------------------------------------------------
+  # Elixir Toolbox
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Format the full Elixir Toolbox taxonomy of groups and categories.
+  """
+  def format_toolbox_groups(groups) do
+    header = "# Elixir Toolbox Groups\n\n#{length(groups)} groups\n\n"
+
+    body =
+      Enum.map_join(groups, "\n\n", fn g ->
+        "## #{g.title} (`#{g.slug}`)\n" <> format_toolbox_categories(g.categories)
+      end)
+
+    header <> body
+  end
+
+  @doc """
+  Format a single Elixir Toolbox group and its categories.
+  """
+  def format_toolbox_group(group) do
+    header = "# #{group.title} (`#{group.slug}`)\n\n#{length(group.categories)} categories\n\n"
+    header <> format_toolbox_categories(group.categories)
+  end
+
+  @doc """
+  Format curated projects in an Elixir Toolbox category.
+  """
+  def format_toolbox_category(group_slug, category_slug, projects) do
+    "# Elixir Toolbox: #{group_slug} / #{category_slug}\n\n#{length(projects)} projects\n\n" <>
+      toolbox_projects_section(projects)
+  end
+
+  @doc """
+  Format trending Elixir Toolbox projects.
+  """
+  def format_toolbox_trending(projects) do
+    "# Trending Elixir Packages\n\n#{length(projects)} projects\n\n" <>
+      toolbox_projects_section(projects)
+  end
+
+  @doc """
+  Format Elixir Toolbox search results.
+  """
+  def format_toolbox_search(query, projects) do
+    "# Elixir Toolbox search: #{query}\n\n#{length(projects)} results\n\n" <>
+      toolbox_projects_section(projects)
+  end
+
+  defp format_toolbox_categories([]), do: "No categories."
+
+  defp format_toolbox_categories(categories) do
+    Enum.map_join(categories, "\n", fn c ->
+      "- `#{c.slug}` #{c.name}: #{c.description}"
+    end)
+  end
+
+  defp toolbox_projects_section([]), do: "No projects found."
+
+  defp toolbox_projects_section(projects) do
+    headers = ["Package", "Version", "Stars", "Recent DLs", "Popularity", "Health"]
+
+    rows =
+      Enum.map(projects, fn p ->
+        [
+          p.name,
+          p.latest_stable_version || "-",
+          format_number(toolbox_stars(p)),
+          format_number(p.downloads["recent"]),
+          format_popularity(p.popularity),
+          format_health(p.health)
+        ]
+      end)
+
+    table = markdown_table(headers, rows)
+
+    details =
+      Enum.map_join(projects, "\n\n", fn p ->
+        "### #{p.name}\n#{p.description}\n- #{p.hex_url}" <>
+          maybe_line("Docs", p.docs_url) <>
+          toolbox_repo_line(p)
+      end)
+
+    table <> "\n\n## Details\n\n" <> details
+  end
+
+  defp toolbox_stars(%{github: %{stars: s}}) when is_integer(s), do: s
+  defp toolbox_stars(%{gitlab: %{stars: s}}) when is_integer(s), do: s
+  defp toolbox_stars(_), do: nil
+
+  defp format_popularity(nil), do: "-"
+  defp format_popularity(p) when is_number(p), do: "#{Float.round(p / 1, 1)}"
+
+  defp format_health([]), do: "-"
+
+  defp format_health(flags) when is_list(flags) do
+    Enum.map_join(flags, ", ", &String.replace(&1, "recently_", ""))
+  end
+
+  defp toolbox_repo_line(%{github: %{name: name}}) when is_binary(name), do: "\n- GitHub: #{name}"
+  defp toolbox_repo_line(%{gitlab: %{name: name}}) when is_binary(name), do: "\n- GitLab: #{name}"
+  defp toolbox_repo_line(_), do: ""
+
+  defp maybe_line(_label, nil), do: ""
+  defp maybe_line(label, value), do: "\n- #{label}: #{value}"
 end

--- a/lib/hexpm_mcp/mcp/resources/toolbox_category.ex
+++ b/lib/hexpm_mcp/mcp/resources/toolbox_category.ex
@@ -1,0 +1,26 @@
+defmodule HexpmMcp.MCP.Resources.ToolboxCategory do
+  @moduledoc "Curated projects in an Elixir Toolbox category"
+
+  use Anubis.Server.Component,
+    type: :resource,
+    name: "toolbox_category",
+    uri_template: "toolbox://{group}/{category}",
+    mime_type: "application/json"
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+
+  @impl true
+  def read(%{"group" => group, "category" => category}, frame) do
+    case HexpmMcp.toolbox_category(group, category) do
+      {:ok, projects} ->
+        {:reply, Response.json(Response.resource(), %{projects: projects}), frame}
+
+      {:error, :not_found} ->
+        {:error, Error.execution("Category not found: #{group}/#{category}"), frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Failed to fetch category projects: #{inspect(reason)}"), frame}
+    end
+  end
+end

--- a/lib/hexpm_mcp/mcp/resources/toolbox_groups.ex
+++ b/lib/hexpm_mcp/mcp/resources/toolbox_groups.ex
@@ -1,0 +1,23 @@
+defmodule HexpmMcp.MCP.Resources.ToolboxGroups do
+  @moduledoc "The Elixir Toolbox curated taxonomy of groups and categories"
+
+  use Anubis.Server.Component,
+    type: :resource,
+    name: "toolbox_groups",
+    uri: "toolbox://groups",
+    mime_type: "application/json"
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+
+  @impl true
+  def read(_params, frame) do
+    case HexpmMcp.toolbox_groups() do
+      {:ok, groups} ->
+        {:reply, Response.json(Response.resource(), %{groups: groups}), frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Failed to list groups: #{inspect(reason)}"), frame}
+    end
+  end
+end

--- a/lib/hexpm_mcp/mcp/server.ex
+++ b/lib/hexpm_mcp/mcp/server.ex
@@ -43,10 +43,19 @@ defmodule HexpmMcp.MCP.Server do
   component(HexpmMcp.MCP.Tools.SearchDocs)
   component(HexpmMcp.MCP.Tools.DocItem)
 
+  # Elixir Toolbox discovery tools
+  component(HexpmMcp.MCP.Tools.ToolboxGroups)
+  component(HexpmMcp.MCP.Tools.ToolboxGroup)
+  component(HexpmMcp.MCP.Tools.ToolboxCategory)
+  component(HexpmMcp.MCP.Tools.ToolboxTrending)
+  component(HexpmMcp.MCP.Tools.ToolboxSearch)
+
   # Resources
   component(HexpmMcp.MCP.Resources.PackageInfo)
   component(HexpmMcp.MCP.Resources.PackageReadme)
   component(HexpmMcp.MCP.Resources.PackageDocs)
+  component(HexpmMcp.MCP.Resources.ToolboxGroups)
+  component(HexpmMcp.MCP.Resources.ToolboxCategory)
 
   # Prompts
   component(HexpmMcp.MCP.Prompts.AnalyzePackage)

--- a/lib/hexpm_mcp/mcp/tools/toolbox_category.ex
+++ b/lib/hexpm_mcp/mcp/tools/toolbox_category.ex
@@ -1,0 +1,48 @@
+defmodule HexpmMcp.MCP.Tools.ToolboxCategory do
+  @moduledoc """
+  List the curated projects in an Elixir Toolbox category.
+  """
+
+  use Anubis.Server.Component, type: :tool
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+  alias HexpmMcp.Formatter
+
+  schema do
+    field(:group, :string, required: true, description: "Group slug (e.g. \"web\", \"ai\")")
+
+    field(:category, :string,
+      required: true,
+      description: "Category slug within the group (e.g. \"frameworks\")"
+    )
+
+    field(:sort, :string,
+      description:
+        "Ordering: \"name\" (alphabetical) or \"downloads\"; defaults to popularity order"
+    )
+  end
+
+  @impl true
+  def execute(%{group: group, category: category} = args, frame) do
+    opts = maybe_put([], :sort, Map.get(args, :sort))
+
+    case HexpmMcp.toolbox_category(group, category, opts) do
+      {:ok, projects} ->
+        {:reply,
+         Response.text(
+           Response.tool(),
+           Formatter.format_toolbox_category(group, category, projects)
+         ), frame}
+
+      {:error, :not_found} ->
+        {:error, Error.execution("Category not found: #{group}/#{category}"), frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Failed to fetch category projects: #{inspect(reason)}"), frame}
+    end
+  end
+
+  defp maybe_put(keyword, _key, nil), do: keyword
+  defp maybe_put(keyword, key, value), do: Keyword.put(keyword, key, value)
+end

--- a/lib/hexpm_mcp/mcp/tools/toolbox_group.ex
+++ b/lib/hexpm_mcp/mcp/tools/toolbox_group.ex
@@ -1,0 +1,29 @@
+defmodule HexpmMcp.MCP.Tools.ToolboxGroup do
+  @moduledoc """
+  List the categories in a single Elixir Toolbox group.
+  """
+
+  use Anubis.Server.Component, type: :tool
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+  alias HexpmMcp.Formatter
+
+  schema do
+    field(:group, :string, required: true, description: "Group slug (e.g. \"web\", \"ai\")")
+  end
+
+  @impl true
+  def execute(%{group: group}, frame) do
+    case HexpmMcp.toolbox_group(group) do
+      {:ok, data} ->
+        {:reply, Response.text(Response.tool(), Formatter.format_toolbox_group(data)), frame}
+
+      {:error, :not_found} ->
+        {:error, Error.execution("Group not found: #{group}"), frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Failed to fetch group: #{inspect(reason)}"), frame}
+    end
+  end
+end

--- a/lib/hexpm_mcp/mcp/tools/toolbox_groups.ex
+++ b/lib/hexpm_mcp/mcp/tools/toolbox_groups.ex
@@ -1,0 +1,25 @@
+defmodule HexpmMcp.MCP.Tools.ToolboxGroups do
+  @moduledoc """
+  Browse the Elixir Toolbox curated taxonomy of groups and categories.
+  """
+
+  use Anubis.Server.Component, type: :tool
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+  alias HexpmMcp.Formatter
+
+  schema do
+  end
+
+  @impl true
+  def execute(_args, frame) do
+    case HexpmMcp.toolbox_groups() do
+      {:ok, groups} ->
+        {:reply, Response.text(Response.tool(), Formatter.format_toolbox_groups(groups)), frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Failed to list groups: #{inspect(reason)}"), frame}
+    end
+  end
+end

--- a/lib/hexpm_mcp/mcp/tools/toolbox_search.ex
+++ b/lib/hexpm_mcp/mcp/tools/toolbox_search.ex
@@ -1,0 +1,28 @@
+defmodule HexpmMcp.MCP.Tools.ToolboxSearch do
+  @moduledoc """
+  Search packages via Elixir Toolbox. Results carry GitHub/GitLab stats,
+  popularity, and health signals not exposed by the raw hex.pm search.
+  """
+
+  use Anubis.Server.Component, type: :tool
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+  alias HexpmMcp.Formatter
+
+  schema do
+    field(:query, :string, required: true, description: "Search query string")
+  end
+
+  @impl true
+  def execute(%{query: query}, frame) do
+    case HexpmMcp.toolbox_search(query) do
+      {:ok, results} ->
+        {:reply, Response.text(Response.tool(), Formatter.format_toolbox_search(query, results)),
+         frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Search failed: #{inspect(reason)}"), frame}
+    end
+  end
+end

--- a/lib/hexpm_mcp/mcp/tools/toolbox_trending.ex
+++ b/lib/hexpm_mcp/mcp/tools/toolbox_trending.ex
@@ -1,0 +1,32 @@
+defmodule HexpmMcp.MCP.Tools.ToolboxTrending do
+  @moduledoc """
+  List trending Elixir packages from Elixir Toolbox.
+  """
+
+  use Anubis.Server.Component, type: :tool
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+  alias HexpmMcp.Formatter
+
+  schema do
+    field(:limit, :integer, description: "Maximum number of projects to return")
+  end
+
+  @impl true
+  def execute(args, frame) do
+    opts = maybe_put([], :limit, Map.get(args, :limit))
+
+    case HexpmMcp.toolbox_trending(opts) do
+      {:ok, projects} ->
+        {:reply, Response.text(Response.tool(), Formatter.format_toolbox_trending(projects)),
+         frame}
+
+      {:error, reason} ->
+        {:error, Error.execution("Failed to fetch trending: #{inspect(reason)}"), frame}
+    end
+  end
+
+  defp maybe_put(keyword, _key, nil), do: keyword
+  defp maybe_put(keyword, key, value), do: Keyword.put(keyword, key, value)
+end

--- a/lib/hexpm_mcp/toolbox.ex
+++ b/lib/hexpm_mcp/toolbox.ex
@@ -1,0 +1,177 @@
+defmodule HexpmMcp.Toolbox do
+  @moduledoc """
+  Client for the Elixir Toolbox API (https://elixir-toolbox.dev).
+
+  Elixir Toolbox is a curated discovery layer over hex.pm: a maintained
+  taxonomy of groups and categories, trending packages, and search. The API
+  is public, requires no authentication, and returns package objects enriched
+  with GitHub/GitLab stats, a popularity score, and health flags.
+
+  Responses are wrapped in a `{"data": ...}` envelope; each function unwraps it
+  and returns parsed maps. Results are cached via `HexpmMcp.Cache`.
+  """
+
+  alias HexpmMcp.Cache
+
+  @base_url "https://elixir-toolbox.dev/api/v1"
+  @user_agent "hexpm-mcp"
+
+  @doc """
+  List all groups, each with its categories.
+  """
+  def groups do
+    Cache.fetch({:toolbox_groups}, fn ->
+      case get("/groups") do
+        {:ok, data} when is_list(data) -> {:ok, Enum.map(data, &parse_group/1)}
+        error -> error
+      end
+    end)
+  end
+
+  @doc """
+  Get a single group by slug.
+  """
+  def group(slug) do
+    Cache.fetch({:toolbox_group, slug}, fn ->
+      case get("/groups/#{slug}") do
+        {:ok, data} when is_map(data) -> {:ok, parse_group(data)}
+        error -> error
+      end
+    end)
+  end
+
+  @doc """
+  List curated projects in a category.
+
+  ## Options
+
+    * `:sort` - result ordering. The API recognizes `"name"` (alphabetical) and
+      `"downloads"`, and falls back to popularity order for any other value.
+  """
+  def category_projects(group, category, opts \\ []) do
+    params = maybe_put([], :sort, opts[:sort])
+
+    Cache.fetch({:toolbox_category, group, category, opts}, fn ->
+      case get("/groups/#{group}/#{category}/projects", params: params) do
+        {:ok, data} when is_list(data) -> {:ok, Enum.map(data, &parse_project/1)}
+        error -> error
+      end
+    end)
+  end
+
+  @doc """
+  List trending projects.
+
+  ## Options
+
+    * `:limit` - maximum number of projects to return.
+  """
+  def trending(opts \\ []) do
+    params = maybe_put([], :limit, opts[:limit])
+
+    Cache.fetch({:toolbox_trending, opts}, fn ->
+      case get("/trending", params: params) do
+        {:ok, data} when is_list(data) -> {:ok, Enum.map(data, &parse_project/1)}
+        error -> error
+      end
+    end)
+  end
+
+  @doc """
+  Search packages by query string.
+  """
+  def search(query) do
+    Cache.fetch({:toolbox_search, query}, fn ->
+      case get("/search", params: [q: query]) do
+        {:ok, data} when is_list(data) -> {:ok, Enum.map(data, &parse_project/1)}
+        error -> error
+      end
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # HTTP
+  # ---------------------------------------------------------------------------
+
+  defp get(path, opts \\ []) do
+    req_opts =
+      [
+        url: base_url() <> path,
+        headers: [{"user-agent", @user_agent}]
+      ] ++ opts
+
+    case Req.get(req_opts) do
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+        {:ok, data}
+
+      {:ok, %Req.Response{status: 200, body: _}} ->
+        {:error, :unexpected_response}
+
+      {:ok, %Req.Response{status: 404}} ->
+        {:error, :not_found}
+
+      {:ok, %Req.Response{status: 400}} ->
+        {:error, :bad_request}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:api_error, status, body}}
+
+      {:error, reason} ->
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  defp base_url, do: Application.get_env(:hexpm_mcp, :toolbox_url, @base_url)
+
+  # ---------------------------------------------------------------------------
+  # Parsing
+  # ---------------------------------------------------------------------------
+
+  defp parse_group(data) when is_map(data) do
+    %{
+      title: data["title"],
+      slug: data["slug"],
+      categories: Enum.map(data["categories"] || [], &parse_category/1)
+    }
+  end
+
+  defp parse_category(data) when is_map(data) do
+    %{
+      name: data["name"],
+      description: data["description"],
+      slug: data["slug"]
+    }
+  end
+
+  defp parse_project(data) when is_map(data) do
+    %{
+      name: data["name"],
+      description: data["description"],
+      latest_stable_version: data["latest_stable_version"],
+      hex_url: data["hex_url"],
+      docs_url: data["docs_url"],
+      updated_at: data["updated_at"],
+      downloads: data["downloads"] || %{},
+      github: parse_repo(data["github"]),
+      gitlab: parse_repo(data["gitlab"]),
+      popularity: data["popularity"],
+      health: data["health"] || []
+    }
+  end
+
+  defp parse_repo(nil), do: nil
+
+  defp parse_repo(repo) when is_map(repo) do
+    %{
+      name: repo["name"],
+      stars: repo["stars"],
+      forks: repo["forks"],
+      open_issues: repo["open_issues"],
+      pushed_at: repo["pushed_at"],
+      archived: repo["archived"]
+    }
+  end
+
+  defp maybe_put(keyword, _key, nil), do: keyword
+  defp maybe_put(keyword, key, value), do: Keyword.put(keyword, key, value)
+end

--- a/test/hexpm_mcp/formatter_test.exs
+++ b/test/hexpm_mcp/formatter_test.exs
@@ -3,6 +3,25 @@ defmodule HexpmMcp.FormatterTest do
 
   alias HexpmMcp.Formatter
 
+  defp toolbox_project(overrides \\ %{}) do
+    Map.merge(
+      %{
+        name: "phoenix",
+        description: "Web framework",
+        latest_stable_version: "1.8.0",
+        hex_url: "https://hex.pm/packages/phoenix",
+        docs_url: "https://phoenix.hexdocs.pm/",
+        updated_at: "2026-01-01T00:00:00Z",
+        downloads: %{"all" => 1000, "recent" => 45_678},
+        github: %{name: "phoenixframework/phoenix", stars: 23_000},
+        gitlab: nil,
+        popularity: 95.5,
+        health: ["recently_released", "recently_committed"]
+      },
+      overrides
+    )
+  end
+
   describe "format_number/1" do
     test "formats millions" do
       assert Formatter.format_number(1_234_567) == "1.2M"
@@ -511,6 +530,77 @@ defmodule HexpmMcp.FormatterTest do
     test "handles no deps" do
       data = %{total_checked: 0, upgrades_available: 0, results: []}
       assert Formatter.format_upgrade_check(data) =~ "No dependencies found to check."
+    end
+  end
+
+  describe "format_toolbox_groups/1" do
+    test "renders groups with their categories" do
+      groups = [
+        %{
+          title: "Web",
+          slug: "web",
+          categories: [%{name: "Frameworks", description: "Web frameworks", slug: "frameworks"}]
+        }
+      ]
+
+      out = Formatter.format_toolbox_groups(groups)
+      assert out =~ "# Elixir Toolbox Groups"
+      assert out =~ "1 groups"
+      assert out =~ "## Web (`web`)"
+      assert out =~ "- `frameworks` Frameworks: Web frameworks"
+    end
+  end
+
+  describe "format_toolbox_group/1" do
+    test "renders a single group" do
+      group = %{
+        title: "AI",
+        slug: "ai",
+        categories: [%{name: "LLM Clients", description: "Call LLM APIs", slug: "llm_clients"}]
+      }
+
+      out = Formatter.format_toolbox_group(group)
+      assert out =~ "# AI (`ai`)"
+      assert out =~ "1 categories"
+      assert out =~ "- `llm_clients` LLM Clients: Call LLM APIs"
+    end
+  end
+
+  describe "format_toolbox_category/3 and project rendering" do
+    test "renders a table and details" do
+      out = Formatter.format_toolbox_category("web", "frameworks", [toolbox_project()])
+      assert out =~ "# Elixir Toolbox: web / frameworks"
+      assert out =~ "| Package"
+      assert out =~ "phoenix"
+      assert out =~ "45.7K"
+      assert out =~ "95.5"
+      assert out =~ "released, committed"
+      assert out =~ "### phoenix"
+      assert out =~ "- GitHub: phoenixframework/phoenix"
+      assert out =~ "- Docs: https://phoenix.hexdocs.pm/"
+    end
+
+    test "falls back to GitLab stars and repo line when no GitHub" do
+      project =
+        toolbox_project(%{
+          github: nil,
+          gitlab: %{name: "group/proj", stars: 500}
+        })
+
+      out = Formatter.format_toolbox_category("web", "frameworks", [project])
+      assert out =~ "- GitLab: group/proj"
+    end
+
+    test "renders placeholders for missing popularity and health" do
+      project = toolbox_project(%{popularity: nil, health: []})
+      out = Formatter.format_toolbox_search("phoenix", [project])
+      assert out =~ "# Elixir Toolbox search: phoenix"
+      # popularity and health both render as "-"
+      assert out =~ "| -"
+    end
+
+    test "handles an empty project list" do
+      assert Formatter.format_toolbox_trending([]) =~ "No projects found."
     end
   end
 end

--- a/test/hexpm_mcp/toolbox_test.exs
+++ b/test/hexpm_mcp/toolbox_test.exs
@@ -1,0 +1,158 @@
+defmodule HexpmMcp.ToolboxTest do
+  use ExUnit.Case
+
+  alias HexpmMcp.Toolbox
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:hexpm_mcp, :toolbox_url, "http://localhost:#{bypass.port}")
+    Application.put_env(:hexpm_mcp, :cache_ttl, 0)
+
+    on_exit(fn ->
+      Application.delete_env(:hexpm_mcp, :toolbox_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp project(name, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "name" => name,
+        "description" => "#{name} description",
+        "latest_stable_version" => "1.0.0",
+        "hex_url" => "https://hex.pm/packages/#{name}",
+        "docs_url" => "https://#{name}.hexdocs.pm/",
+        "updated_at" => "2026-01-01T00:00:00Z",
+        "downloads" => %{"all" => 1000, "recent" => 500, "week" => 50, "day" => 5},
+        "github" => %{
+          "name" => "owner/#{name}",
+          "stars" => 42,
+          "forks" => 3,
+          "open_issues" => 1,
+          "pushed_at" => "2026-01-01T00:00:00Z",
+          "archived" => false
+        },
+        "popularity" => 12.5,
+        "health" => ["recently_committed"]
+      },
+      overrides
+    )
+  end
+
+  describe "groups/0" do
+    test "unwraps the data envelope and parses categories", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/groups", fn conn ->
+        json(conn, 200, %{
+          "data" => [
+            %{
+              "title" => "Web",
+              "slug" => "web",
+              "categories" => [
+                %{
+                  "name" => "Frameworks",
+                  "description" => "Web frameworks",
+                  "slug" => "frameworks"
+                }
+              ]
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, [group]} = Toolbox.groups()
+      assert group.slug == "web"
+      assert [category] = group.categories
+      assert category.slug == "frameworks"
+      assert category.name == "Frameworks"
+    end
+  end
+
+  describe "group/1" do
+    test "parses a single group", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/groups/web", fn conn ->
+        json(conn, 200, %{
+          "data" => %{"title" => "Web", "slug" => "web", "categories" => []}
+        })
+      end)
+
+      assert {:ok, %{slug: "web", categories: []}} = Toolbox.group("web")
+    end
+
+    test "returns :not_found on 404", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/groups/nope", fn conn ->
+        json(conn, 404, %{"error" => "not found"})
+      end)
+
+      assert {:error, :not_found} = Toolbox.group("nope")
+    end
+  end
+
+  describe "category_projects/3" do
+    test "parses projects and forwards the sort param", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/groups/web/frameworks/projects", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["sort"] == "downloads"
+        json(conn, 200, %{"data" => [project("phoenix")]})
+      end)
+
+      assert {:ok, [p]} = Toolbox.category_projects("web", "frameworks", sort: "downloads")
+      assert p.name == "phoenix"
+      assert p.popularity == 12.5
+      assert p.github.stars == 42
+      assert p.health == ["recently_committed"]
+    end
+
+    test "omits the sort param when not given", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/groups/web/frameworks/projects", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        refute Map.has_key?(conn.query_params, "sort")
+        json(conn, 200, %{"data" => []})
+      end)
+
+      assert {:ok, []} = Toolbox.category_projects("web", "frameworks")
+    end
+  end
+
+  describe "trending/1" do
+    test "forwards the limit param", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/trending", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["limit"] == "5"
+        json(conn, 200, %{"data" => [project("req_llm", %{"gitlab" => nil})]})
+      end)
+
+      assert {:ok, [p]} = Toolbox.trending(limit: 5)
+      assert p.name == "req_llm"
+      assert p.gitlab == nil
+    end
+  end
+
+  describe "search/1" do
+    test "forwards the query and parses results", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["q"] == "phoenix"
+        json(conn, 200, %{"data" => [project("phoenix", %{"github" => nil, "gitlab" => nil})]})
+      end)
+
+      assert {:ok, [p]} = Toolbox.search("phoenix")
+      assert p.name == "phoenix"
+      assert p.github == nil
+    end
+
+    test "returns :bad_request on 400", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        json(conn, 400, %{"error" => "bad query"})
+      end)
+
+      assert {:error, :bad_request} = Toolbox.search("")
+    end
+  end
+end


### PR DESCRIPTION
Closes #58

## Summary

Adds a client for the [Elixir Toolbox API](https://elixir-toolbox.dev/api) (`https://elixir-toolbox.dev/api/v1`), a curated discovery layer over hex.pm, and exposes it as MCP tools and resources. The API is public, needs no auth, and returns package objects enriched with GitHub/GitLab stats, a `popularity` score, and `health` flags that the raw hex.pm API does not expose.

## Tools

| Tool | Args | Endpoint |
|---|---|---|
| `toolbox_groups` | none | `GET /groups` |
| `toolbox_group` | `group` | `GET /groups/{group}` |
| `toolbox_category` | `group`, `category`, `sort?` | `GET /groups/{group}/{category}/projects` |
| `toolbox_trending` | `limit?` | `GET /trending` |
| `toolbox_search` | `query` | `GET /search?q=` |

Prefixed `toolbox_` to distinguish curated discovery from the raw hex.pm tools and avoid colliding with the existing bare `search`.

## Resources

- `toolbox://groups` -- the full taxonomy as JSON
- `toolbox://{group}/{category}` -- curated projects in a category as JSON

## Implementation

Mirrors the existing `osv.ex` client pattern:

- `lib/hexpm_mcp/toolbox.ex` -- HTTP client with its own base URL (overridable via the `:toolbox_url` app env for tests), cache-backed via `HexpmMcp.Cache`, unwrapping the `{"data": ...}` envelope.
- One parser handles both response shapes: `/search` returns `Package` objects; `/trending` and category projects return `Project` objects (adding `popularity` and `health`). Both `github` and `gitlab` repo blocks are nullable and handled.
- Five `Formatter.format_toolbox_*` functions render markdown (tables plus a details section, matching existing style).
- Five thin tool wrappers and two resources, registered in `mcp/server.ex`.
- `HexpmMcp.toolbox_*` delegates keep the functions usable from iex.

## Open questions resolved

- **`sort` values:** probing the live API showed the server recognizes `name` (alphabetical) and `downloads` as distinct orderings and silently falls back to popularity order otherwise. The `sort` arg is an optional string documenting these, rather than a hard-restricted enum.
- **Resources:** added, per the issue (`toolbox://groups` plus a category template), symmetric with the tools.

## Testing

- `test/hexpm_mcp/toolbox_test.exs` -- Bypass-mocked client tests: envelope unwrapping, category parsing, `sort`/`limit`/`q` param forwarding, nullable repos, and 404/400 error mapping.
- Formatter tests covering the taxonomy render, project table, GitLab fallback, and missing-popularity/health placeholders.

Local gates: `mix test` (105 passing), `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` all pass.