### PR TITLE
chore: sync server.json to 0.3.4 and cut release

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.joshrotenberg/hexpm-mcp",
   "title": "Hex.pm MCP",
   "description": "MCP server for hex.pm and hexdocs.pm: search, inspect, compare, audit, and discover Elixir packages",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "websiteUrl": "https://github.com/joshrotenberg/hexpm-mcp",
   "repository": {
     "url": "https://github.com/joshrotenberg/hexpm-mcp",


### PR DESCRIPTION
Forces a v0.3.4 release via a `Release-As: 0.3.4` footer, and fixes the `server.json` version lag (0.3.1 -> 0.3.4) flagged during the doc audit.

## Why

The Elixir Toolbox feature shipped in v0.3.3, but the README/docs updates ([#61](https://github.com/joshrotenberg/hexpm-mcp/pull/61)) and the reusable deploy workflow ([#63](https://github.com/joshrotenberg/hexpm-mcp/pull/63)) landed as `docs:`/`ci:` commits, which release-please does not release on. This cuts a patch release so:

- the updated README (with the Toolbox tools) publishes to Hex.pm / hexdocs, and
- the new reusable deploy path runs end to end, recording the first entry in the Deployments/Environments view.

## Mechanism

The squash commit carries `Release-As: 0.3.4`, which makes release-please open a 0.3.4 release PR even though the change itself is a `chore`.

## Note

Longer term, `server.json` could be added to release-please `extra-files` so its version bumps automatically. Left as a follow-up.