### PR TITLE
ci: modernize workflow actions to Node 24 and auto-version server.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
@@ -24,7 +24,7 @@ jobs:
           otp-version: "28"
 
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
@@ -62,7 +62,7 @@ jobs:
           otp-version: "28"
 
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -71,7 +71,7 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-
 
       - name: Cache PLT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _build/dev/*.plt
           key: ${{ runner.os }}-plt-${{ hashFiles('mix.lock') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Elixir
         uses: erlef/setup-beam@v1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,14 @@
     ".": {
       "release-type": "elixir",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Two CI/release maintenance items flagged during the v0.3.4 release.

## 1. Node 24 action versions

The v0.3.4 run emitted Node 20 deprecation warnings: GitHub was force-running `actions/checkout@v4`, `actions/cache@v4`, and `googleapis/release-please-action@v4` on Node 24 because those pinned versions ship Node 20.

Pinned all three to their Node-24 `v5` majors:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `googleapis/release-please-action` | v4 | v5 |

`erlef/setup-beam@v1` already runs on Node 24 (v1.24.1), left as is. Verified each `v5` tag reports `using: node24`. `release-please-action` v5's only breaking change is the Node 24 upgrade (no behavior/config change), and checkout v5's is a runner-minimum-version bump that GitHub-hosted runners satisfy. Our usage of all three is default/trivial.

## 2. Auto-version server.json

`server.json`'s version was bumped by hand and had drifted (0.3.1 while the package was 0.3.3; corrected to 0.3.4 in #64). Added it to release-please `extra-files` so its `$.version` updates alongside `mix.exs` on every release:

```json
"extra-files": [
  { "type": "json", "path": "server.json", "jsonpath": "$.version" }
]
```

Takes effect on the next release PR.

## Verification

- `actionlint` clean (only pre-existing SC2086 info notes in the deploy verify script).
- Both JSON files validated.
- CI on this PR exercises the bumped `checkout`/`cache` in the test and dialyzer jobs.