### PR TITLE
ci: pin flyctl-actions/setup-flyctl to a release tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Fly CLI
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@1.5
 
       - name: Deploy to Fly.io
         run: flyctl deploy --remote-only


### PR DESCRIPTION
`deploy.yml` used `superfly/flyctl-actions/setup-flyctl@master`, which floats on whatever `master` points to at deploy time. Pin it to `@1.5` (the latest published release) for reproducible, auditable deploys.

Only affects the deploy job's Fly CLI setup; behavior is otherwise unchanged (the action installs flyctl either way).

Note: this action only runs in the deploy path (release-triggered or manual dispatch), so CI here validates syntax only; it will next execute on the next deploy.