### PR TITLE
fix: grant the attestation permissions release.yml needs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches: [main]
 
+# id-token and attestations are needed by the binaries job. A reusable workflow
+# cannot request more than its caller was granted, and release.yml declares both
+# for build provenance attestations, so omitting them here makes GitHub reject
+# this whole file at startup with only "workflow file issue" to go on.
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   release-please:


### PR DESCRIPTION
The `binaries` job added in #68 broke Release Please at startup. `main` currently
cannot run it at all.

`release.yml` declares `id-token: write` and `attestations: write` so tinfoil can
attach build provenance attestations to the uploaded archives. A reusable
workflow cannot request more permissions than its caller was granted, and
`release-please.yml` granted only `contents: write` and `pull-requests: write`,
so GitHub rejected the whole file before any job started.

The only diagnostic GitHub gives is:

```
X This run likely failed because of a workflow file issue.
```

No annotation, and the API returns 404 for both annotations and jobs, because no
jobs were ever created. Nothing points at permissions.

Grants both permissions to the caller, which is the narrower fix. The
alternative is `attestations: false` in the `:tinfoil` config, which drops the
permissions from the generated workflow but also drops provenance.

Verified by parsing the workflow and confirming all four jobs still resolve.
Merging this should let Release Please run and open the release PR for #68.