### PR TITLE
ci: cross-compile the darwin targets from Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
       matrix:
         include:
           - id: darwin
-            targets: "darwin_arm64,darwin_x86_64"
-            runner: macos-latest
+            targets: "darwin_arm64_cross,darwin_x86_64_cross"
+            runner: ubuntu-latest
           - id: linux
             targets: "linux_x86_64,linux_arm64"
             runner: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -157,13 +157,40 @@ defmodule HexpmMcp.MixProject do
 
   defp tinfoil do
     [
+      # darwin is cross-compiled from Linux rather than built on a macOS
+      # runner. macos-latest is now macos-26-arm64, and Zig 0.15.2 (what burrito
+      # 1.5.x requires) cannot link against the macOS 26 SDK. Cross-compiling
+      # sidesteps the host SDK entirely: Zig uses its own bundled macOS libc
+      # stubs. This is the same approach tinfoil already takes for Windows.
+      #
+      # extra_targets cannot shadow a builtin target name, so these carry a
+      # _cross suffix. The triples are unchanged, so asset names are identical
+      # to a native build.
       targets: [
-        :darwin_arm64,
-        :darwin_x86_64,
+        :darwin_arm64_cross,
+        :darwin_x86_64_cross,
         :linux_x86_64,
         :linux_arm64,
         :windows_x86_64
       ],
+      extra_targets: %{
+        darwin_arm64_cross: %{
+          runner: "ubuntu-latest",
+          burrito_os: :darwin,
+          burrito_cpu: :aarch64,
+          triple: "aarch64-apple-darwin",
+          archive_ext: ".tar.gz",
+          os_family: :darwin
+        },
+        darwin_x86_64_cross: %{
+          runner: "ubuntu-latest",
+          burrito_os: :darwin,
+          burrito_cpu: :x86_64,
+          triple: "x86_64-apple-darwin",
+          archive_ext: ".tar.gz",
+          os_family: :darwin
+        }
+      },
       single_runner_per_os: true,
       extra_artifacts: [
         "LICENSE",


### PR DESCRIPTION
Removes a failure that is waiting for the next release.

## Why

`macos-latest` is now `macos-26-arm64`:

```
Image: macos-26-arm64
```

Zig 0.15.2, which burrito 1.5.x requires, cannot link against the macOS 26 SDK.
On this host the identical toolchain fails with:

```
error: undefined symbol: __availability_version_check
error: undefined symbol: _dispatch_queue_create
error: undefined symbol: _arc4random_buf
...
```

CI has never actually exercised a Burrito build. Every job so far died at the
version check before Burrito started, so this has been latent rather than
observed. Rather than spend a release cycle finding out, it is cheaper to remove
the dependency on the macOS SDK.

## What

Cross-compile darwin from Linux. Zig only reaches for the host SDK when linking
natively; cross-compiling uses its own bundled macOS libc stubs.

Verified end to end. Built `darwin_arm64` in a Linux container, then ran the
result natively on macOS 26:

```
$ file hexpm_mcp_darwin_arm64
Mach-O 64-bit executable arm64

$ ./hexpm_mcp_darwin_arm64 --version
hexpm_mcp 0.3.4

$ ./hexpm_mcp_darwin_arm64 --transport stdio < handshake.jsonl
{"id":1,"jsonrpc":"2.0","result":{...,"serverInfo":{"name":"hexpm-mcp","version":"0.3.4"}}}
{"id":2,"jsonrpc":"2.0","result":{"tools":[...]}}
```

Exit 0 on stdin close as well. A macOS binary built on Linux, running correctly
on macOS 26.

This is the same approach tinfoil already uses for Windows, which cross-compiles
from `ubuntu-latest` rather than using a Windows runner.

## Notes

`extra_targets` cannot shadow a builtin target name, so these carry a `_cross`
suffix. The triples are unchanged, so published asset names are identical to a
native build:

```
  target               burrito         runner         archive
  darwin_arm64_cross   darwin_arm64    ubuntu-latest  hexpm_mcp-0.3.5-aarch64-apple-darwin.tar.gz
  darwin_x86_64_cross  darwin_x86_64   ubuntu-latest  hexpm_mcp-0.3.5-x86_64-apple-darwin.tar.gz
  linux_x86_64         linux_x86_64    ubuntu-latest  hexpm_mcp-0.3.5-x86_64-unknown-linux-musl.tar.gz
  linux_arm64          linux_arm64     ubuntu-latest  hexpm_mcp-0.3.5-aarch64-unknown-linux-musl.tar.gz
  windows_x86_64       windows_x86_64  ubuntu-latest  hexpm_mcp-0.3.5-x86_64-pc-windows-msvc.zip
```

All three build jobs are now `ubuntu-latest`, which also drops the dependency on
`macos-15-intel` before GitHub retires it in 2027, and cuts runner cost since
macOS minutes bill at a multiple of Linux.

## This does not fix v0.3.5

The generated workflow checks out the tag, not the branch:

```yaml
- uses: actions/checkout@v5
  with:
    ref: "${{ inputs.tag || github.event.release.tag_name }}"
```

`v0.3.5` pins `tinfoil ~> 0.2.21`, whose `tinfoil.build` ignores `--tag` and
falls back to `GITHUB_REF_NAME`, which under `workflow_call` is the caller's
branch. So dispatching against `v0.3.5` rebuilds the broken version check no
matter what is on main. That is correct behavior for reproducibility, but it
means v0.3.5 cannot be backfilled and the fixes only take effect from the next
tag.

0.3.5 remains published on Hex and deployed to Fly, with no release binaries. The
next release is the first one that can produce them.