### PR TITLE
feat: surface the http endpoint path

### DIFF
--- a/lib/hexpm_mcp/application.ex
+++ b/lib/hexpm_mcp/application.ex
@@ -3,6 +3,8 @@ defmodule HexpmMcp.Application do
 
   use Application
 
+  require Logger
+
   # start/2 halts on --help, --version, and usage errors, so it does not always
   # return. That is intended for a CLI entry point, not a defect.
   @dialyzer {:nowarn_function, start: 2}
@@ -28,7 +30,21 @@ defmodule HexpmMcp.Application do
   defp start_supervisor(opts) do
     children = [HexpmMcp.Cache] ++ transport_children(opts)
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: HexpmMcp.Supervisor)
+    with {:ok, pid} <-
+           Supervisor.start_link(children, strategy: :one_for_one, name: HexpmMcp.Supervisor) do
+      log_endpoint(opts)
+      {:ok, pid}
+    end
+  end
+
+  # Bandit's own startup line reports the bind address but not the path, and the
+  # server only answers on /mcp. Clients that guess the root get a 404, so say
+  # where it is. Logging goes to stderr, so this is safe in stdio mode too, but
+  # there is no endpoint to report there.
+  defp log_endpoint(opts) do
+    if Keyword.fetch!(opts, :transport) == :http do
+      Logger.info("MCP endpoint: http://localhost:#{port(opts)}/mcp")
+    end
   end
 
   defp transport_children(opts) do

--- a/lib/hexpm_mcp/cli.ex
+++ b/lib/hexpm_mcp/cli.ex
@@ -28,6 +28,8 @@ defmodule HexpmMcp.CLI do
     after_help("""
     The default transport depends on how the server was started: stdio for the
     standalone binary, http otherwise. Pass --transport to be explicit.
+
+    The http transport serves MCP at /mcp, e.g. http://localhost:8765/mcp.
     """)
 
     option(:transport,

--- a/lib/hexpm_mcp/mcp/router.ex
+++ b/lib/hexpm_mcp/mcp/router.ex
@@ -14,7 +14,9 @@ defmodule HexpmMcp.MCP.Router do
     StreamableHTTP.Plug.call(conn, opts)
   end
 
+  # Clients that guess the root, which several do, get told where to look
+  # instead of a bare "not found".
   defp route(conn, _opts) do
-    Plug.Conn.send_resp(conn, 404, "not found")
+    Plug.Conn.send_resp(conn, 404, "not found: the MCP endpoint is at /mcp\n")
   end
 end

--- a/test/hexpm_mcp/mcp/router_test.exs
+++ b/test/hexpm_mcp/mcp/router_test.exs
@@ -1,0 +1,33 @@
+defmodule HexpmMcp.MCP.RouterTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+  import Plug.Conn
+
+  alias HexpmMcp.MCP.Router
+
+  describe "unmatched paths" do
+    test "the root says where the MCP endpoint actually is" do
+      conn = Router.call(conn(:get, "/"), [])
+
+      assert conn.status == 404
+      assert conn.resp_body =~ "/mcp"
+    end
+
+    test "any other path does the same" do
+      conn = Router.call(conn(:post, "/rpc"), [])
+
+      assert conn.status == 404
+      assert conn.resp_body =~ "/mcp"
+    end
+  end
+
+  describe "/mcp" do
+    test "is handed to the MCP transport rather than falling through to 404" do
+      # The test env starts no MCP server (transport: :none), so the transport
+      # raises looking up its session config. Raising from inside Anubis is the
+      # assertion: the request reached the transport instead of our 404 clause.
+      assert_raise ArgumentError, fn -> Router.call(conn(:get, "/mcp"), []) end
+    end
+  end
+end


### PR DESCRIPTION
The server answers MCP only on `/mcp`, and nothing told you that.

Observed while pointing `mcp-repl` at a locally running binary:

```
$ hexpm_mcp -t http -p 1234
[info] Running HexpmMcp.MCP.Router with Bandit 1.12.0 at 0.0.0.0:1234 (http)

$ mcp-repl --http http://0.0.0.0:1234
ERROR Transport send error: HTTP 404 from http://0.0.0.0:1234: MCP endpoint not
found (check the endpoint path; some servers serve MCP at the root, others at /mcp)

$ mcp-repl --http http://0.0.0.0:1234/mcp
connected: hexpm-mcp v0.3.6 (protocol 2025-11-25)
```

Bandit's startup line reports the bind address but not the path, `--help` said
nothing about it, and the router's fallback returned a bare `not found`. The
client had to guess, and the guess it makes first is the root.

## Changes

Startup log for the http transport:

```
[info] Running HexpmMcp.MCP.Router with Bandit 1.12.0 at 0.0.0.0:8791 (http)
[info] MCP endpoint: http://localhost:8791/mcp
```

Informative 404:

```
$ curl http://localhost:8791/
not found: the MCP endpoint is at /mcp
```

And `--help` gains a line:

```
The http transport serves MCP at /mcp, e.g. http://localhost:8765/mcp.
```

## Notes

Logging goes to stderr, so the startup line cannot corrupt the stdio protocol.
It is only emitted for the http transport in any case, and stdio has no endpoint
to report.

Adds router tests covering the 404 body and that `/mcp` is handed to the
transport rather than falling through. Verified live: `GET /` returns the new
body, `GET /mcp` returns 406 from the transport, which is the correct rejection
of a request without MCP's required Accept headers.