### PR TITLE
chore: use ASCII punctuation in the generated installer scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -67,7 +67,7 @@ try {
   try {
     Invoke-WebRequest -Uri $SumsUrl -OutFile $SumsPath -UseBasicParsing
     # Each line in checksums-sha256.txt is "<sha>  <filename>" (two
-    # spaces). Match by suffix — PowerShell's -like uses * as wildcard,
+    # spaces). Match by suffix; PowerShell's -like uses * as wildcard,
     # no regex escaping needed. Handle both "  name" and "  *name"
     # (the binary-mode prefix some tools emit).
     $line = Get-Content $SumsPath | Where-Object {


### PR DESCRIPTION
`scripts/install.ps1` line 70 carries an em dash in a comment. `install.sh` was
normalized in #74; this finishes the pair.

Both are hand-edits to generated files and will be reverted by
`mix tinfoil.generate` until joshrotenberg/tinfoil#122 ships. Noted alongside the
other installer edits in the packaging notes.