### PR TITLE
docs: add an Installation section and correct the API count

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,68 @@ A public instance is running at `https://hexpm-mcp.fly.dev/mcp`. Add it to your 
 }
 ```
 
+## Installation
+
+Three ways to get it, depending on how you want to use it.
+
+### Standalone binary (recommended)
+
+A self-contained binary for macOS, Linux, and Windows. It bundles the Erlang
+runtime, so no Elixir toolchain is required.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/joshrotenberg/hexpm-mcp/main/scripts/install.sh | sh
+```
+
+The installer resolves the latest release, picks the asset for your OS and
+architecture, verifies its sha256, and installs to `~/.local/bin`. It will tell
+you if that directory is not on your `PATH`.
+
+To choose a different directory or pin a version, pass the flags through `sh`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/joshrotenberg/hexpm-mcp/main/scripts/install.sh | sh -s -- --install-dir /usr/local/bin
+curl -fsSL https://raw.githubusercontent.com/joshrotenberg/hexpm-mcp/main/scripts/install.sh | sh -s -- --version v0.3.6
+```
+
+Windows uses the PowerShell equivalent:
+
+```powershell
+iex (irm https://raw.githubusercontent.com/joshrotenberg/hexpm-mcp/main/scripts/install.ps1)
+```
+
+Every [release](https://github.com/joshrotenberg/hexpm-mcp/releases) also
+attaches the archives and a combined `checksums-sha256.txt` if you would rather
+install by hand.
+
+Verify it works:
+
+```sh
+hexpm_mcp --version
+```
+
+See [Usage](#usage) for the MCP client config, and
+[macOS: "Apple could not verify hexpm_mcp"](#macos-apple-could-not-verify-hexpm_mcp)
+if Gatekeeper blocks a browser-downloaded copy.
+
+### As an Elixir library
+
+For the public API from iex or your own code, without running an MCP server:
+
+```elixir
+def deps do
+  [{:hexpm_mcp, "~> 0.3"}]
+end
+```
+
+### From source
+
+```sh
+git clone https://github.com/joshrotenberg/hexpm-mcp.git
+cd hexpm-mcp
+mix deps.get
+```
+
 ## Features
 
 - 24 tools for searching, inspecting, comparing, auditing, and discovering hex.pm packages
@@ -149,18 +211,7 @@ Checked 10 dependencies. 8 warning(s) across 7 package(s).
 
 ### Standalone binary (stdio)
 
-Each release publishes a self-contained binary for macOS, Linux, and Windows. It
-bundles the Erlang runtime, so no Elixir toolchain is required.
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/joshrotenberg/hexpm-mcp/main/scripts/install.sh | sh
-```
-
-The installer resolves the latest release, picks the right asset for your
-OS and architecture, verifies its sha256, and installs to `~/.local/bin`.
-Binaries and a combined `checksums-sha256.txt` are also attached to every
-[GitHub release](https://github.com/joshrotenberg/hexpm-mcp/releases) if you
-prefer to install by hand.
+Once [installed](#standalone-binary-recommended):
 
 ```json
 {
@@ -175,6 +226,13 @@ prefer to install by hand.
 
 The binary defaults to stdio, so `args` can be omitted. Run `hexpm_mcp --help`
 for the full option list.
+
+To serve over HTTP instead, pass `--transport http`. MCP is served at `/mcp`:
+
+```sh
+hexpm_mcp --transport http --port 1234
+# MCP endpoint: http://localhost:1234/mcp
+```
 
 #### macOS: "Apple could not verify hexpm_mcp"
 
@@ -218,16 +276,8 @@ To run from a checkout, e.g. for development:
 
 ### iex
 
-The public API is available directly from iex without the MCP server. Add the
-package to your `mix.exs`:
-
-```elixir
-def deps do
-  [{:hexpm_mcp, "~> 0.3"}]
-end
-```
-
-Or run it straight from a checkout:
+The public API is available directly from iex without the MCP server, either
+via the [Hex dependency](#as-an-elixir-library) or straight from a checkout:
 
 ```elixir
 $ MIX_ENV=test iex -S mix
@@ -264,7 +314,7 @@ iex> HexpmMcp.audit_mix_deps(~s({:phoenix, "~> 1.7"}, {:jason, "~> 1.0"}))
 
 ## API Reference
 
-All 25 functions return `{:ok, structured_map}` or `{:error, reason}`.
+Every function returns `{:ok, structured_map}` or `{:error, reason}`.
 
 ```elixir
 # Search and lookup
@@ -323,6 +373,8 @@ iex / Elixir code                 MCP clients
 - **`HexpmMcp.OSV`** -- OSV.dev vulnerability database client
 - **`HexpmMcp.Toolbox`** -- Elixir Toolbox client for curated package discovery
 - **`HexpmMcp.Cache`** -- ETS-based response cache with TTL and periodic sweeping
+- **`HexpmMcp.CLI`** -- Cheer command tree; turns argv into the server's configuration
+- **`HexpmMcp.MCP.StdioLifecycle`** -- exits 0 when a stdio client disconnects
 - **MCP Tools** -- thin wrappers calling the public API, registered via Anubis Server Components
 
 ## Development

--- a/lib/hexpm_mcp/cli.ex
+++ b/lib/hexpm_mcp/cli.ex
@@ -2,7 +2,7 @@ defmodule HexpmMcp.CLI do
   @moduledoc """
   Command-line interface for the server.
 
-  `HexpmMcp.Application.start/2` is the real entry point in every mode. Burrito
+  The OTP application callback is the real entry point in every mode. Burrito
   boots the BEAM and hands control to the OTP application callback; it never
   calls a `main/1`, and the `main_module` release key is metadata only. So this
   module turns argv into configuration and lets `start/2` build the supervision


### PR DESCRIPTION
Docs pass ahead of the next release.

## The main problem

Install instructions existed, but at line 150, behind the tool tables and sample
output. Quick Start offered only the hosted instance, and there was no
`## Installation` heading anywhere. Someone landing on the README had no visible
path to the binary we now ship.

`## Installation` now sits directly after Quick Start with three options: the
standalone binary, the Hex dependency, and a source checkout. The install
mechanics moved out of `## Usage`, which keeps only client wiring, so nothing is
stated twice.

## Also fixed

- **Flag passing.** The text said "pass `--install-dir`" without showing that
  piped flags need `sh -s --`, so following it verbatim would fail.
- **PowerShell installer.** `scripts/install.ps1` ships but was never mentioned.
- **HTTP transport.** `--transport http` and the `/mcp` endpoint path were absent.
- **API count.** "All 25 functions" sat above a list of 24. Both were right:
  `HexpmMcp` exports 25, but `parse_deps_string/1` is `@doc false`. Replaced with
  a sentence that cannot drift.
- **Architecture list.** Missing `HexpmMcp.CLI` and `HexpmMcp.MCP.StdioLifecycle`.
- **ex_doc warning.** `HexpmMcp.CLI`'s moduledoc autolinked
  `HexpmMcp.Application.start/2`, which is `@moduledoc false` and hidden. That
  was the only warning in the docs build that ships to hexdocs.

## Verified rather than assumed

- all three documented installer invocations produce a working binary, including
  the bare default-directory form under a sandboxed `HOME`
- every internal anchor resolves to a real heading
- the documented tool tables match the 24 registered tools exactly, no drift
- `mix docs` is warning-free
- format, `compile --warnings-as-errors`, `credo --strict`, 123 tests

## Not changed

`server.json` still advertises only the hosted `streamable-http` remote. Now that
binaries ship it could plausibly gain a `packages` entry, but I did not want to
guess at registry schema fields immediately before a release, since an invalid
manifest would break registry publishing. Worth looking at separately.